### PR TITLE
Execute ldconfig after installing. Applies Dockerfile best-practices.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,24 @@ FROM ubuntu:16.04
 
 MAINTAINER Ansgar Schmidt <ansgar.schmidt@gmx.net>
 
-ENV DEBIAN_FRONTEND noninteractive
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install \
+  build-essential \
+  libc-ares-dev \
+  libssl-dev \
+  libwrap0-dev \
+  python-distutils-extra \
+  uuid-dev \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install wget build-essential libwrap0-dev libssl-dev python-distutils-extra libc-ares-dev uuid-dev -y
 RUN mkdir -p /usr/local/src
 WORKDIR /usr/local/src
-RUN wget http://mosquitto.org/files/source/mosquitto-1.4.9.tar.gz
-RUN tar xvzf ./mosquitto-1.4.9.tar.gz
+RUN wget http://mosquitto.org/files/source/mosquitto-1.4.9.tar.gz && tar -xzvf ./mosquitto-1.4.9.tar.gz
+
 WORKDIR /usr/local/src/mosquitto-1.4.9
-RUN make
-RUN make install
+RUN make && make install && /sbin/ldconfig
 RUN adduser --system --disabled-password --disabled-login mosquitto
+
 USER mosquitto
 EXPOSE 1883
 CMD ["/usr/local/sbin/mosquitto"]


### PR DESCRIPTION
Fixes #4.
Also improves Dockerfile size and performance by applying Dockerfile best-practices. See https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/