### PR TITLE
update to 1.4.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get upgrade -y
 RUN apt-get install wget build-essential libwrap0-dev libssl-dev python-distutils-extra libc-ares-dev uuid-dev -y
 RUN mkdir -p /usr/local/src
 WORKDIR /usr/local/src
-RUN wget http://mosquitto.org/files/source/mosquitto-1.4.9.tar.gz
-RUN tar xvzf ./mosquitto-1.4.9.tar.gz
-WORKDIR /usr/local/src/mosquitto-1.4.9
+RUN wget http://mosquitto.org/files/source/mosquitto-1.4.10.tar.gz
+RUN tar xvzf ./mosquitto-1.4.10.tar.gz
+WORKDIR /usr/local/src/mosquitto-1.4.10
 RUN make
 RUN make install
 RUN adduser --system --disabled-password --disabled-login mosquitto

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Mosquitto
 =========
 
 Docker build file for mosquitto. This docker file is based on
-ubuntu 16.04 and mosquitto version 1.4.9
+ubuntu 16.04 and mosquitto version 1.4.10
 
 Get it
 ======


### PR DESCRIPTION
https://mosquitto.org/ChangeLog.txt

1.4.10 - 20160816
=================

Broker:
- Fix TLS operation with websockets listeners and libwebsockts 2.x. Closes
  #186.
- Don't disconnect client on HUP before reading the pending data. Closes #7.
- Fix some $SYS messages being incorrectly persisted. Closes #191.
- Support OpenSSL 1.1.0.
- Call fsync after persisting data to ensure it is correctly written. Closes
  #189.
- Fix persistence saving of subscription QoS on big-endian machines.
- Fix will retained flag handling on Windows. Closes #222.
- Broker now displays an error if it is unable to open the log file. Closes
  #234.

Client library:
- Support OpenSSL 1.1.0.
- Fixed the C++ library not allowing SOCKS support to be used. Closes #198.
- Fix memory leak when verifying a server certificate with a subjectAltName
  section. Closes #237.

Build:
- Don't attempt to install docs when WITH_DOCS=no. Closes #184.